### PR TITLE
Add partition to filtering options

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,11 @@ import DocumentsTable from "@/components/documents-table";
 export default async function Home({
   searchParams,
 }: {
-  searchParams: { cursor?: string; filter?: string };
+  searchParams: { 
+    cursor?: string; 
+    filter?: string;
+    partition?: string;
+  };
 }) {
   return (
     <main className="min-h-screen p-10">
@@ -27,7 +31,10 @@ export default async function Home({
           <div className="flex gap-10">
             <CreateDocumentForm />
             <Suspense fallback={<div>Loading...</div>}>
-              <DocumentsTable filter={searchParams.filter || ""} />
+              <DocumentsTable 
+                filter={searchParams.filter || ""} 
+                partition={searchParams.partition || ""}
+              />
             </Suspense>
           </div>
         </TabsContent>

--- a/components/documents-table.tsx
+++ b/components/documents-table.tsx
@@ -17,18 +17,21 @@ import UpdateDocumentDialog from "./update-document-dialog";
 
 export default async function DocumentsTable({
   filter,
+  partition,
   cursor,
 }: {
   filter?: string;
+  partition?: string;
   cursor?: string;
 }) {
   const listRes = await ragie.documents.list({
     cursor,
     filter,
+    partition,
   });
   return (
     <div>
-      <MetadataFilter filter={filter} />
+      <MetadataFilter filter={filter} partition={partition} />
       <Table className="border">
         <TableHeader>
           <TableRow>
@@ -69,7 +72,7 @@ export default async function DocumentsTable({
             <TableCell className="text-right" colSpan={6}>
               {listRes.result.pagination.nextCursor && (
                 <Link
-                  href={`/?cursor=${listRes.result.pagination.nextCursor}&filter=${filter}`}
+                  href={`/?cursor=${listRes.result.pagination.nextCursor}&filter=${filter}&partition=${partition}`}
                 >
                   Next
                 </Link>

--- a/components/metadata-filter.tsx
+++ b/components/metadata-filter.tsx
@@ -5,8 +5,15 @@ import { useRouter } from "next/navigation";
 
 import { Button } from "./ui/button";
 import { Textarea } from "./ui/textarea";
+import { Input } from "./ui/input";
 
-export default function MetadataFilter({ filter }: { filter?: string }) {
+export default function MetadataFilter({ 
+  filter,
+  partition 
+}: { 
+  filter?: string;
+  partition?: string;
+}) {
   const router = useRouter();
   return (
     <form
@@ -15,18 +22,31 @@ export default function MetadataFilter({ filter }: { filter?: string }) {
         evt.preventDefault();
         const formData = new FormData(evt.target as HTMLFormElement);
         const filter = (formData.get("filter") as string) || "";
-        router.push(`/?filter=${filter}`);
+        const partition = (formData.get("partition") as string) || "";
+        router.push(`/?filter=${filter}&partition=${partition}`);
       }}
     >
-      <label htmlFor="filter">Filter</label>
-      <Textarea
-        name="filter"
-        placeholder={'{ "foo": {"$eq": "bar"}'}
-        defaultValue={filter}
-      />
-      <Button type="submit" variant="secondary">
-        Filter
-      </Button>
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="filter">Filter</label>
+          <Textarea
+            name="filter"
+            placeholder={'{ "foo": {"$eq": "bar"}'}
+            defaultValue={filter}
+          />
+        </div>
+        <div>
+          <label htmlFor="partition">Partition</label>
+          <Input
+            name="partition"
+            placeholder="user_123"
+            defaultValue={partition}
+          />
+        </div>
+        <Button type="submit" variant="secondary">
+          Filter
+        </Button>
+      </div>
     </form>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "next": "14.2.5",
         "npm": "^10.8.2",
         "prettier": "^3.3.2",
-        "ragie": "^0.9.0",
+        "ragie": "^1.3.6",
         "react": "^18",
         "react-dom": "^18",
         "tailwind-merge": "^2.4.0",
@@ -6813,9 +6813,9 @@
       ]
     },
     "node_modules/ragie": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/ragie/-/ragie-0.9.0.tgz",
-      "integrity": "sha512-RHAai8H6kYPo0S3XzhSVPEVXsp5NHr4rsveol9In8GHrrTaXskf5OrqvCcGvFae4mCC1GTZsCJTIV7eB4zjyZA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/ragie/-/ragie-1.3.6.tgz",
+      "integrity": "sha512-e4lXSNBPw9y3Oyhln7JTMeuyRb3XJgQ6bk76C9BtgfSDr3akxdKlbZqZIQ1w/Dtse89O9QpAQx4WxU2M1hNHJw==",
       "peerDependencies": {
         "zod": ">= 3"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "next": "14.2.5",
     "npm": "^10.8.2",
     "prettier": "^3.3.2",
-    "ragie": "^0.9.0",
+    "ragie": "^1.3.6",
     "react": "^18",
     "react-dom": "^18",
     "tailwind-merge": "^2.4.0",


### PR DESCRIPTION
Add a text box to the documents tab where you can enter a partition key. The partition is passed along to ragie along with the filter when determining which documents to show in the documents table. This also requires some simple changes to the state and routing, a well as updating the version of the ragie typescript SDK.